### PR TITLE
Add simple Chargeamps Halo client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # smart_charger
+
+This repository contains a simple Python client for interacting with a Chargeamps Halo charger.
+
+## Requirements
+
+The scripts rely only on the Python standard library and therefore do not require any third-party packages.
+
+## Usage
+
+The `cli.py` script provides a small command-line interface. The charger must expose an HTTP API compatible with the endpoints used in `halo_client.py`.
+
+```bash
+python3 cli.py --host http://halo.local --api-key YOUR_KEY --charger-id CHARGER_ID status
+```
+
+Supported commands are:
+
+- `status` – display current charger status
+- `start` – begin charging
+- `stop` – stop charging
+
+See `halo_client.py` for the API calls performed.

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Command-line interface for interacting with a Chargeamps Halo charger."""
+
+import argparse
+import json
+from halo_client import HaloClient
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Interact with Chargeamps Halo charger")
+    parser.add_argument("--host", required=True, help="Base URL of the charger API")
+    parser.add_argument("--api-key", required=True, help="API key for authentication")
+    parser.add_argument("--charger-id", required=True, help="ID of the charger to control")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("status", help="Show charger status")
+    subparsers.add_parser("start", help="Start charging")
+    subparsers.add_parser("stop", help="Stop charging")
+
+    args = parser.parse_args()
+
+    client = HaloClient(args.host, args.api_key)
+
+    if args.command == "status":
+        result = client.get_status(args.charger_id)
+        print(json.dumps(result, indent=2))
+    elif args.command == "start":
+        client.start_charging(args.charger_id)
+        print("Charging started")
+    elif args.command == "stop":
+        client.stop_charging(args.charger_id)
+        print("Charging stopped")
+
+
+if __name__ == "__main__":
+    main()

--- a/halo_client.py
+++ b/halo_client.py
@@ -1,0 +1,42 @@
+import json
+import urllib.request
+
+class HaloClient:
+    """Simple client for Chargeamps Halo charger API."""
+
+    def __init__(self, host: str, api_key: str):
+        self.host = host.rstrip('/')
+        self.api_key = api_key
+
+    def _request(self, method: str, path: str, data: dict | None = None):
+        url = f"{self.host}{path}"
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        body = None
+        if data is not None:
+            body = json.dumps(data).encode("utf-8")
+        req = urllib.request.Request(
+            url,
+            data=body,
+            headers=headers,
+            method=method,
+        )
+        with urllib.request.urlopen(req) as resp:
+            resp_body = resp.read()
+            if not resp_body:
+                return None
+            return json.loads(resp_body.decode())
+
+    def get_status(self, charger_id: str):
+        """Return charger status."""
+        return self._request("GET", f"/api/chargers/{charger_id}/status")
+
+    def start_charging(self, charger_id: str):
+        """Start charging."""
+        return self._request("POST", f"/api/chargers/{charger_id}/charge/start")
+
+    def stop_charging(self, charger_id: str):
+        """Stop charging."""
+        return self._request("POST", f"/api/chargers/{charger_id}/charge/stop")


### PR DESCRIPTION
## Summary
- provide a `HaloClient` class for talking to the Halo charger via HTTP
- add a small `cli.py` tool for command line access
- document how to use the client

## Testing
- `python3 -m py_compile halo_client.py cli.py`
- `pytest -q` *(fails: command not found)*